### PR TITLE
Support disabled nodeIntegration

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -27,15 +27,33 @@ Api.prototype.addApiCommands = function (api) {
 
 Api.prototype.load = function () {
   var self = this
-  return this.getVersion().then(function (version) {
-    var api = apiCache[version]
-    if (api) return api
+  return this.isNodeIntegrationEnabled().then(function (nodeIntegration) {
+    self.nodeIntegration = nodeIntegration
+    if (!nodeIntegration)  {
+      return {
+        electron: {remote: {}},
+        browserWindow: {},
+        webContents: {},
+        rendererProcess: {}
+      }
+    }
 
-    return self.loadApi().then(function (api) {
-      apiCache[version] = api
-      return api
+    return self.getVersion().then(function (version) {
+      var api = apiCache[version]
+      if (api) return api
+
+      return self.loadApi().then(function (api) {
+        apiCache[version] = api
+        return api
+      })
     })
   })
+}
+
+Api.prototype.isNodeIntegrationEnabled = function () {
+  return this.app.client.execute(function () {
+    return typeof process !== 'undefined'
+  }).then(getResponseValue)
 }
 
 Api.prototype.getVersion = function () {

--- a/lib/api.js
+++ b/lib/api.js
@@ -29,7 +29,7 @@ Api.prototype.load = function () {
   var self = this
   return this.isNodeIntegrationEnabled().then(function (nodeIntegration) {
     self.nodeIntegration = nodeIntegration
-    if (!nodeIntegration)  {
+    if (!nodeIntegration) {
       return {
         electron: {remote: {}},
         browserWindow: {},

--- a/lib/application.js
+++ b/lib/application.js
@@ -47,7 +47,7 @@ Application.prototype.stop = function () {
   if (!self.isRunning()) return Promise.reject(Error('Application not running'))
 
   return new Promise(function (resolve, reject) {
-    self.client.windowByIndex(0).electron.remote.app.quit().then(function () {
+    var endClient = function () {
       setTimeout(function () {
         self.client.end().then(function () {
           self.chromeDriver.stop()
@@ -55,7 +55,15 @@ Application.prototype.stop = function () {
           resolve(self)
         }, reject)
       }, self.quitTimeout)
-    }, reject)
+    }
+
+    if (self.api.nodeIntegration) {
+      self.client.windowByIndex(0).electron.remote.app.quit().then(endClient, reject)
+    } else {
+      self.client.windowByIndex(0).execute(function () {
+        window.close()
+      }).then(endClient, reject)
+    }
   })
 }
 

--- a/test/fixtures/no-node-integration/index.html
+++ b/test/fixtures/no-node-integration/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>no node integration</title>
+  </head>
+  <body>
+    no node integration
+  </body>
+</html>

--- a/test/fixtures/no-node-integration/main.js
+++ b/test/fixtures/no-node-integration/main.js
@@ -1,0 +1,19 @@
+var app = require('electron').app
+var BrowserWindow = require('electron').BrowserWindow
+var path = require('path')
+
+var mainWindow = null
+
+app.on('ready', function () {
+  mainWindow = new BrowserWindow({
+    x: 25,
+    y: 35,
+    width: 200,
+    height: 100,
+    webPreferences: {
+      nodeIntegration: false
+    }
+  })
+  mainWindow.loadURL('file://' + __dirname + '/index.html')
+  mainWindow.on('closed', function () { mainWindow = null })
+})

--- a/test/fixtures/no-node-integration/main.js
+++ b/test/fixtures/no-node-integration/main.js
@@ -1,6 +1,5 @@
 var app = require('electron').app
 var BrowserWindow = require('electron').BrowserWindow
-var path = require('path')
 
 var mainWindow = null
 

--- a/test/fixtures/no-node-integration/package.json
+++ b/test/fixtures/no-node-integration/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "Test",
+  "version": "1.0.0",
+  "main": "main.js"
+}

--- a/test/global-setup.js
+++ b/test/global-setup.js
@@ -25,6 +25,7 @@ exports.setupTimeout = function (test) {
 
 exports.startApplication = function (options) {
   options.path = exports.getElectronPath()
+  if (process.env.CI) options.startTimeout = 30000
 
   var app = new Application(options)
   return app.start().then(function () {

--- a/test/no-node-integration-test.js
+++ b/test/no-node-integration-test.js
@@ -1,0 +1,27 @@
+var helpers = require('./global-setup')
+var path = require('path')
+
+var describe = global.describe
+var it = global.it
+var beforeEach = global.beforeEach
+var afterEach = global.afterEach
+
+describe('when nodeIntegration is set to false', function () {
+  helpers.setupTimeout(this)
+
+  var app = null
+
+  beforeEach(function () {
+    return helpers.startApplication({
+      args: [path.join(__dirname, 'fixtures', 'no-node-integration')]
+    }).then(function (startedApp) { app = startedApp })
+  })
+
+  afterEach(function () {
+    return helpers.stopApplication(app)
+  })
+
+  it('does not throw an error', function () {
+    return app.client.getTitle().should.eventually.equal('no node integration')
+  })
+})

--- a/test/no-node-integration-test.js
+++ b/test/no-node-integration-test.js
@@ -23,5 +23,6 @@ describe('when nodeIntegration is set to false', function () {
 
   it('does not throw an error', function () {
     return app.client.getTitle().should.eventually.equal('no node integration')
+      .getText('body').should.eventually.equal('no node integration')
   })
 })


### PR DESCRIPTION
Support applications that have `nodeIntegration: false` in their BrowserWindow's `webPreferences` options.

Fixes #28