### PR TITLE
Use afterEach.always in ava sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,21 +443,21 @@ test.beforeEach(async t => {
   await t.context.app.start();
 });
 
-test.afterEach(async t => {
+test.afterEach.always(async t => {
   await t.context.app.stop();
 });
 
 test(async t => {
   const app = t.context.app;
   await app.client.waitUntilWindowLoaded();
-  
+
   const win = app.browserWindow;
   t.is(await app.client.getWindowCount(), 1);
   t.false(await win.isMinimized());
   t.false(await win.isDevToolsOpened());
   t.true(await win.isVisible());
   t.true(await win.isFocused());
-  
+
   const {width, height} = await win.getBounds();
   t.true(width > 0);
   t.true(height > 0);


### PR DESCRIPTION
From ava 0.15, `after.always` and `afterEach.always` runners are added.  They ensure to stop application even if test failed.