### PR TITLE
Add async BrowserWindow.capturePage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ app.browserWindow.isVisible().then(function (visible) {
 It is named `browserWindow` instead of `window` so that it doesn't collide
 with the WebDriver command of that name.
 
+##### capturePage
+
+The async `capturePage` API is supported but instead of taking a callback it
+returns a `Promise` that resolves to a `Buffer` that is the image data of
+screenshot.
+
+```js
+app.browserWindow.capturePage().then(function (imageBuffer) {
+  fs.writeFile('page.png', imageBuffer)
+})
+```
+
 #### webContents
 
 The `webContents` property is an alias for `require('electron').remote.getCurrentWebContents()`.

--- a/lib/api.js
+++ b/lib/api.js
@@ -273,7 +273,13 @@ Api.prototype.addBrowserWindowApis = function (api) {
   var self = this
   app.browserWindow = {}
 
-  Object.keys(api).forEach(function (name) {
+  const asyncApis = {
+    'browserWindow.capturePage': true
+  }
+
+  Object.keys(api).filter(function (name) {
+    return !asyncApis.hasOwnProperty(api[name])
+  }).forEach(function (name) {
     var commandName = api[name]
 
     app.client.addCommand(commandName, function () {
@@ -285,6 +291,36 @@ Api.prototype.addBrowserWindowApis = function (api) {
       return app.client[commandName].apply(app.client, arguments)
     }
   })
+
+  this.addCapturePageSupport()
+}
+
+Api.prototype.addCapturePageSupport = function () {
+  var app = this.app
+  var self = this
+
+  app.client.addCommand('browserWindow.capturePage', function (rect) {
+    return this.executeAsync(function (rect, requireName, done) {
+      var args = []
+      if (rect != null) args.push(rect)
+      args.push(function (image) {
+        if (image != null) {
+          done(image.toPng().toString('base64'))
+        } else {
+          done(image)
+        }
+      })
+
+      var browserWindow = window[requireName]('electron').remote.getCurrentWindow()
+      browserWindow.capturePage.apply(browserWindow, args)
+    }, rect, self.requireName).then(getResponseValue).then(function (image) {
+      return new Buffer(image, 'base64')
+    })
+  })
+
+  app.browserWindow.capturePage = function () {
+    return app.client['browserWindow.capturePage'].apply(app.client, arguments)
+  }
 }
 
 Api.prototype.addWebContentsApis = function (api) {

--- a/lib/application.js
+++ b/lib/application.js
@@ -41,6 +41,7 @@ Application.prototype.start = function () {
     .then(function () { return self.startChromeDriver() })
     .then(function () { return self.createClient() })
     .then(function () { return self.api.initialize() })
+    .then(function () { return self.client.timeoutsAsyncScript(self.waitTimeout) })
     .then(function () { self.running = true })
     .then(function () { return self })
 }

--- a/test/application-test.js
+++ b/test/application-test.js
@@ -179,4 +179,25 @@ describe('application loading', function () {
       return app.electron.remote.getGlobal('mainProcessGlobal').should.eventually.equal('foo')
     })
   })
+
+  describe('browserWindow.capturePage', function () {
+    it('returns a Buffer screenshot of the given rectangle', function () {
+      return app.browserWindow.capturePage({
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10
+      }).then(function (buffer) {
+        expect(buffer).to.be.an.instanceof(Buffer)
+        expect(buffer.length).to.be.above(0)
+      })
+    })
+
+    it('returns a Buffer screenshot of the entire page when no rectangle is specified', function () {
+      return app.browserWindow.capturePage().then(function (buffer) {
+        expect(buffer).to.be.an.instanceof(Buffer)
+        expect(buffer.length).to.be.above(0)
+      })
+    })
+  })
 })


### PR DESCRIPTION
The [BrowserWindow.capturePage](http://electron.atom.io/docs/api/browser-window/#wincapturepagerect-callback) API is async and returns a `nativeImage` so it previously did not work because of the async part and because the `nativeImage` can't be serialized as JSON.

This pull requests adds custom support for it so that `app.browserWindow.capturePage` returns a promise that resolves to a node `Buffer` containing the image data.

It can be used in specs like so:

```js
app.browserWindow.capturePage().then(function (imageBuffer) {
  fs.writeFile('page.png', imageBuffer)
})
```

/cc @jlord 🍐 

Closes #46 