### PR TITLE
Support async webContents.savePage API

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,21 @@ app.webContents.isLoading().then(function (visible) {
 })
 ```
 
+##### savePage
+
+The async `savePage` API is supported but instead of taking a callback it
+returns a `Promise` that will raise any errors and resolve to `undefined` when
+complete.
+
+```js
+app.webContents.savePage('/Users/kevin/page.html', 'HTMLComplete')
+  .then(function () {
+    console.log('page saved')
+  }).catch(function (error) {
+    console.error('saving page failed', error.message)
+  })
+```
+
 #### mainProcess
 
 The `mainProcess` property is an alias for `require('electron').remote.process`.

--- a/lib/api.js
+++ b/lib/api.js
@@ -328,7 +328,13 @@ Api.prototype.addWebContentsApis = function (api) {
   var self = this
   app.webContents = {}
 
-  Object.keys(api).forEach(function (name) {
+  const asyncApis = {
+    'webContents.savePage': true
+  }
+
+  Object.keys(api).filter(function (name) {
+    return !asyncApis.hasOwnProperty(api[name])
+  }).forEach(function (name) {
     var commandName = api[name]
 
     app.client.addCommand(commandName, function () {
@@ -340,6 +346,30 @@ Api.prototype.addWebContentsApis = function (api) {
       return app.client[commandName].apply(app.client, arguments)
     }
   })
+
+  this.addSavePageSupport()
+}
+
+Api.prototype.addSavePageSupport = function () {
+  var app = this.app
+  var self = this
+
+  app.client.addCommand('webContents.savePage', function (fullPath, saveType) {
+    return this.executeAsync(function (fullPath, saveType, requireName, done) {
+      var webContents = window[requireName]('electron').remote.getCurrentWebContents()
+      webContents.savePage(fullPath, saveType, done)
+    }, fullPath, saveType, self.requireName).then(getResponseValue).then(function (rawError) {
+      if (rawError) {
+        var error = new Error(rawError.message)
+        if (rawError.name) error.name = rawError.name
+        throw error
+      }
+    })
+  })
+
+  app.webContents.savePage = function () {
+    return app.client['webContents.savePage'].apply(app.client, arguments)
+  }
 }
 
 Api.prototype.addProcessApis = function (api) {

--- a/test/application-test.js
+++ b/test/application-test.js
@@ -200,4 +200,19 @@ describe('application loading', function () {
       })
     })
   })
+
+  describe('webContents.savePage', function () {
+    it('saves the page to the specified path', function () {
+      var filePath = path.join(tempPath, 'page.html')
+      return app.webContents.savePage(filePath, 'HTMLComplete').then(function () {
+        var html = fs.readFileSync(filePath, 'utf8')
+        expect(html).to.contain('<title>Test</title>')
+        expect(html).to.contain('Hello')
+      })
+    })
+
+    it('throws an error when the specified path is invalid', function () {
+      return app.webContents.savePage(tempPath, 'MHTML').should.be.rejectedWith(Error)
+    })
+  })
 })


### PR DESCRIPTION
Similar to #47 this adds support for the save `webContents.savePage` API.

```js
app.webContents.savePage('/Users/kevin/page.html', 'HTMLComplete')
  .then(function () {
    console.log('page saved')
  }).catch(function (error) {
    console.error('saving page failed', error.message)
  })
```
