### PR TITLE
Don't add properties when nodeIntegration is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,28 @@ Create a new application with the following options:
   `waitUntilTextExists` and `waitUntilWindowLoaded` to complete.
   Defaults to `5000` milliseconds.
 
+### Node Integration
+
+The Electron helpers provided by Spectron require accessing the core Electron
+APIs in the renderer processes of your application. So if your Electron
+application has `nodeIntegration` set to `false` then you'll need to expose a
+`require` window global to Spectron so it can access the core Electron APIs.
+
+You can do this by adding a [`preload`][preload] script that does the following:
+
+```js
+if (process.env.NODE_ENV === 'test') {
+  window.electronRequire = require
+}
+```
+
+Then create the Spectron `Application` with the `requireName` option set to
+`'electronRequire'` and then runs your tests via `NODE_ENV=test npm test`.
+
+**Note:** This is only required if you tests are accessing any Electron APIs.
+You don't need to do this if you are only accessing the helpers on the `client`
+property which do not require Node integration.
+
 ### Properties
 
 #### client
@@ -490,3 +512,5 @@ test(async t => {
   t.true(height > 0);
 });
 ```
+
+[preload]: http://electron.atom.io/docs/api/browser-window/#new-browserwindowoptions

--- a/lib/api.js
+++ b/lib/api.js
@@ -10,6 +10,8 @@ Api.prototype.initialize = function () {
 }
 
 Api.prototype.addApiCommands = function (api) {
+  if (!this.nodeIntegration) return
+
   this.addRenderProcessApis(api.electron)
   this.addMainProcessApis(api.electron.remote)
   this.addBrowserWindowApis(api.browserWindow)
@@ -394,6 +396,8 @@ Api.prototype.addProcessApis = function (api) {
 
 Api.prototype.transferPromiseness = function (target, promise) {
   this.app.client.transferPromiseness(target, promise)
+
+  if (!this.nodeIntegration) return
 
   var addProperties = function (source, target, moduleName) {
     var sourceModule = source[moduleName]

--- a/lib/api.js
+++ b/lib/api.js
@@ -52,9 +52,9 @@ Api.prototype.load = function () {
 }
 
 Api.prototype.isNodeIntegrationEnabled = function () {
-  return this.app.client.execute(function () {
-    return typeof process !== 'undefined'
-  }).then(getResponseValue)
+  return this.app.client.execute(function (requireName) {
+    return typeof window[requireName] === 'function'
+  }, this.requireName).then(getResponseValue)
 }
 
 Api.prototype.getVersion = function () {

--- a/lib/api.js
+++ b/lib/api.js
@@ -46,7 +46,7 @@ Api.prototype.load = function () {
       if (api) return api
 
       return self.loadApi().then(function (api) {
-        apiCache[version] = api
+        if (version) apiCache[version] = api
         return api
       })
     })
@@ -61,7 +61,7 @@ Api.prototype.isNodeIntegrationEnabled = function () {
 
 Api.prototype.getVersion = function () {
   return this.app.client.execute(function () {
-    return process.versions.electron
+    if (typeof process === 'object') return process.versions.electron
   }).then(getResponseValue)
 }
 
@@ -159,6 +159,8 @@ Api.prototype.loadApi = function () {
     }
 
     function addProcess () {
+      if (typeof process !== 'object') return
+
       for (var name in process) {
         if (ignoreApi(name)) continue
         api.rendererProcess[name] = 'process.' + name

--- a/test/fixtures/require-name/index.html
+++ b/test/fixtures/require-name/index.html
@@ -3,10 +3,6 @@
   <head>
     <meta charset="utf-8">
     <title>require name</title>
-    <script>
-      window.electronRequire = window.require
-      delete window.require
-    </script>
   </head>
   <body>
     custom require name

--- a/test/fixtures/require-name/main.js
+++ b/test/fixtures/require-name/main.js
@@ -1,5 +1,6 @@
 var app = require('electron').app
 var BrowserWindow = require('electron').BrowserWindow
+var path = require('path')
 
 var mainWindow = null
 
@@ -8,7 +9,11 @@ app.on('ready', function () {
     x: 25,
     y: 35,
     width: 200,
-    height: 100
+    height: 100,
+    webPreferences: {
+      nodeIntegration: false,
+      preload: path.join(__dirname, 'preload.js')
+    }
   })
   mainWindow.loadURL('file://' + __dirname + '/index.html')
   mainWindow.on('closed', function () { mainWindow = null })

--- a/test/fixtures/require-name/preload.js
+++ b/test/fixtures/require-name/preload.js
@@ -1,0 +1,1 @@
+window.electronRequire = require

--- a/test/no-node-integration-test.js
+++ b/test/no-node-integration-test.js
@@ -1,5 +1,6 @@
 var helpers = require('./global-setup')
 var path = require('path')
+var expect = require('chai').expect
 
 var describe = global.describe
 var it = global.it
@@ -24,5 +25,12 @@ describe('when nodeIntegration is set to false', function () {
   it('does not throw an error', function () {
     return app.client.getTitle().should.eventually.equal('no node integration')
       .getText('body').should.eventually.equal('no node integration')
+  })
+
+  it('does not add Electron API helper methods', function () {
+    expect(app.browserWindow).to.be.undefined
+    expect(app.webContents).to.be.undefined
+    expect(app.mainProcess).to.be.undefined
+    expect(app.rendererProcess).to.be.undefined
   })
 })

--- a/test/no-node-integration-test.js
+++ b/test/no-node-integration-test.js
@@ -33,5 +33,11 @@ describe('when nodeIntegration is set to false', function () {
     expect(app.webContents).to.be.undefined
     expect(app.mainProcess).to.be.undefined
     expect(app.rendererProcess).to.be.undefined
+
+    expect(app.client.electron).to.be.undefined
+    expect(app.client.browserWindow).to.be.undefined
+    expect(app.client.webContents).to.be.undefined
+    expect(app.client.mainProcess).to.be.undefined
+    expect(app.client.rendererProcess).to.be.undefined
   })
 })

--- a/test/no-node-integration-test.js
+++ b/test/no-node-integration-test.js
@@ -12,13 +12,13 @@ describe('when nodeIntegration is set to false', function () {
 
   var app = null
 
-  beforeEach(function () {
+  before(function () {
     return helpers.startApplication({
       args: [path.join(__dirname, 'fixtures', 'no-node-integration')]
     }).then(function (startedApp) { app = startedApp })
   })
 
-  afterEach(function () {
+  after(function () {
     return helpers.stopApplication(app)
   })
 

--- a/test/no-node-integration-test.js
+++ b/test/no-node-integration-test.js
@@ -4,8 +4,8 @@ var expect = require('chai').expect
 
 var describe = global.describe
 var it = global.it
-var beforeEach = global.beforeEach
-var afterEach = global.afterEach
+var before = global.before
+var after = global.after
 
 describe('when nodeIntegration is set to false', function () {
   helpers.setupTimeout(this)

--- a/test/no-node-integration-test.js
+++ b/test/no-node-integration-test.js
@@ -28,6 +28,7 @@ describe('when nodeIntegration is set to false', function () {
   })
 
   it('does not add Electron API helper methods', function () {
+    expect(app.electron).to.be.undefined
     expect(app.browserWindow).to.be.undefined
     expect(app.webContents).to.be.undefined
     expect(app.mainProcess).to.be.undefined


### PR DESCRIPTION
Certain helpers require node integration enabled in the app, either via setting `nodeIntegration: true` in the `BrowserWindow` options or defining a custom `requireName` when creating the `Application`.

This pull request removes the `nodeIntegration` dependent properties from the `Application` and `app.client` properties so they generate errors when called instead of via a rejected promise.

Closes #51 