### PR TITLE
More changes for debuggerAddress setting

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -87,16 +87,12 @@ Application.prototype.isRunning = function () {
 Application.prototype.exists = function () {
   var self = this
   return new Promise(function (resolve, reject) {
-    if (self.debuggerAddress) {
-      // if debuggerAddress is set, binary (from path) is being ignored by ChromeDriver
-      return resolve();
-    } else {
-      fs.stat(self.path, function (error, stat) {
-        if (error) return reject(error)
-        if (stat.isFile()) return resolve()
-        reject(Error('Application path specified is not a file: ' + self.path))
-      })
-    }
+    if (self.debuggerAddress) return resolve(); // if debuggerAddress is set, binary (from path) is being ignored by ChromeDriver
+    fs.stat(self.path, function (error, stat) {
+      if (error) return reject(error)
+      if (stat.isFile()) return resolve()
+      reject(Error('Application path specified is not a file: ' + self.path))
+    })
   })
 }
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -87,11 +87,16 @@ Application.prototype.isRunning = function () {
 Application.prototype.exists = function () {
   var self = this
   return new Promise(function (resolve, reject) {
-    fs.stat(self.path, function (error, stat) {
-      if (error) return reject(error)
-      if (stat.isFile()) return resolve()
-      reject(Error('Application path specified is not a file: ' + self.path))
-    })
+    if (self.debuggerAddress) {
+      // if debuggerAddress is set, binary (from path) is being ignored by ChromeDriver
+      return resolve();
+    } else {
+      fs.stat(self.path, function (error, stat) {
+        if (error) return reject(error)
+        if (stat.isFile()) return resolve()
+        reject(Error('Application path specified is not a file: ' + self.path))
+      })
+    }
   })
 }
 


### PR DESCRIPTION
Hello Kevin

When debuggerAddress is set, ChromeDriver ignores binary and assumes the application is started externally.  So, I made a change to skip validation of 'path' if debuggerAddress is set.

Thanks
Wenjun