### PR TITLE
Add description about that <webview> tags are treated as windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ app.client.getSelectedText().then(function (selectedText) {
 #### client.getWindowCount()
 
 Gets the number of open windows.
+`<webview>` tags are also counted as separate windows.
 
 ```js
 app.client.getWindowCount().then(function (count) {
@@ -351,6 +352,7 @@ app.client.waitUntilWindowLoaded(10000)
 #### client.windowByIndex(index)
 
 Focus a window using its index from the `windowHandles()` array.
+`<webview>` tag can also be focused as a separate window.
 
 ```js
 app.client.windowByIndex(1)


### PR DESCRIPTION
As written in #6, `<webview>` is treated as a window. I think that it's not obviously for new people.
Of course they can know the behavior by executing tests or searching issues, but it would be better to write to README.