### PR TITLE
Allow path to be an object with script and electron paths inside

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -91,11 +91,25 @@ Application.prototype.exists = function () {
     // Binary path is ignored by ChromeDriver if debuggerAddress is set
     if (self.debuggerAddress) return resolve()
 
-    fs.stat(self.path, function (error, stat) {
-      if (error) return reject(error)
-      if (stat.isFile()) return resolve()
-      reject(Error('Application path specified is not a file: ' + self.path))
-    })
+    if (typeof self.path === 'string') {
+      fs.stat(self.path, function (error, stat) {
+        if (error) return reject(error)
+        if (stat.isFile()) return resolve()
+        reject(Error('Application path specified is not a file: ' + self.path))
+      })
+    } else if (self.path && (typeof self.path === 'object')) {
+      fs.stat(self.path.script, function (error, stat) {
+        if (error) return reject(error)
+        if (!stat.isFile()) reject(Error('Script path specified is not a file: ' + self.path.script))
+        fs.stat(self.path.electron, function (error, stat) {
+          if (error) return reject(error)
+          if (stat.isFile()) return resolve()
+          reject(Error('Electron path specified is not a file: ' + self.path.electron))
+        })
+      })
+    } else {
+      reject(Error('Invalid path option: ' + self.path))
+    }
   })
 }
 
@@ -108,7 +122,12 @@ Application.prototype.createClient = function () {
   var self = this
   return new Promise(function (resolve, reject) {
     var args = []
-    args.push('spectron-path=' + self.path)
+    if (typeof self.path === 'string') {
+      args.push('spectron-path=' + self.path)
+    } else {
+      args.push('spectron-electron-path=' + self.path.electron)
+      args.push('spectron-script-path=' + self.path.script)
+    }
     self.args.forEach(function (arg, index) {
       args.push('spectron-arg' + index + '=' + arg)
     })

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -17,6 +17,10 @@ process.argv.slice(2).forEach(function (arg) {
   var value = arg.substring(indexOfEqualSign + 1)
   if (name === '--spectron-path') {
     executablePath = value
+  } else if (name === '--spectron-electron-path') {
+    executablePath = value
+  } else if (name === '--spectron-script-path') {
+    appArgs.push(value)
   } else if (name.indexOf('--spectron-arg') === 0) {
     appArgs.push(value)
   } else if (name.indexOf('--spectron-env') === 0) {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -20,7 +20,7 @@ process.argv.slice(2).forEach(function (arg) {
   } else if (name === '--spectron-electron-path') {
     executablePath = value
   } else if (name === '--spectron-script-path') {
-    appArgs.push(value)
+    appArgs.unshift(value)
   } else if (name.indexOf('--spectron-arg') === 0) {
     appArgs.push(value)
   } else if (name.indexOf('--spectron-env') === 0) {


### PR DESCRIPTION
This patch gives an option in setup for starting electron app:
 - path is a string, it must be pointing to a completely assembled electron application;
 - path is an object with two fields, script and electron, pointing respectively to a script and electron in a development environment.

First option already exists, and this patch gives second option. Skipping assembling of an application, i.e. providing electron and app script paths simplifies setup, and speeds things up at development time.