### PR TITLE
Better setup method for spectron

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ describe('application launch', function () {
 
   beforeEach(function () {
     this.app = new Application({
-      path: '/Applications/MyApp.app/Contents/MacOS/MyApp'
+      path: path.join(__dirname, '..', 'node_modules', '.bin', 'electron'),
+      args: [
+        path.join(__dirname, '..')
+      ]
     })
     return this.app.start()
   })


### PR DESCRIPTION
Most developers probably don't have their apps in their `/Applications` folder. This is a better method because it makes no assumptions about the setup.