### PR TITLE
Add support for ignoring accessibility rules by code value

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ Run an accessibility audit in the focused window with the specified options.
 * `options` - An optional Object with the following keys:
   * `ignoreWarnings` - `true` to ignore failures with a severity of `'Warning'`
     and only include failures with a severity of `'Severe'`. Defaults to `false`.
+  * `ignoreRules` - Array of String rule code values such as `AX_COLOR_01`.
+    The full list is available [here](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules).
 
 Returns an `audit` Object with the following properties:
 

--- a/README.md
+++ b/README.md
@@ -371,8 +371,8 @@ Run an accessibility audit in the focused window with the specified options.
 * `options` - An optional Object with the following keys:
   * `ignoreWarnings` - `true` to ignore failures with a severity of `'Warning'`
     and only include failures with a severity of `'Severe'`. Defaults to `false`.
-  * `ignoreRules` - Array of String rule code values such as `AX_COLOR_01`.
-    The full list is available [here](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules).
+  * `ignoreRules` - Array of String rule code values such as `AX_COLOR_01` to
+    ignore failures for. The full list is available [here](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules).
 
 Returns an `audit` Object with the following properties:
 

--- a/lib/accessibility.js
+++ b/lib/accessibility.js
@@ -2,10 +2,11 @@ var axsPath = require.resolve('../vendor/axs_testing')
 
 exports.addCommand = function (client, requireName) {
   client.addCommand('auditAccessibility', function (options) {
-    options = options || {}
-    var ignoreWarnings = options.ignoreWarnings || false
+    return this.execute(function (axsPath, requireName, options) {
+      options = options || {}
+      var ignoreWarnings = options.ignoreWarnings || false
+      var ignoreRules = Array.isArray(options.ignoreRules) ? options.ignoreRules : []
 
-    return this.execute(function (axsPath, requireName, ignoreWarnings) {
       var axs = window[requireName](axsPath)
       var audit = axs.Audit.run(new axs.AuditConfiguration({
         showUnsupportedRulesWarning: false
@@ -20,6 +21,10 @@ exports.addCommand = function (client, requireName) {
           return result.rule.severity !== 'Warning'
         })
       }
+
+      failures = failures.filter(function (result) {
+        return ignoreRules.indexOf(result.rule.code) === -1
+      })
 
       if (failures.length > 0) {
         var message = 'Accessibilty audit failed\n\n'
@@ -49,7 +54,7 @@ exports.addCommand = function (client, requireName) {
           failed: false
         }
       }
-    }, axsPath, requireName, ignoreWarnings).then(function (response) {
+    }, axsPath, requireName, options).then(function (response) {
       return response.value
     })
   })

--- a/test/accessibility-test.js
+++ b/test/accessibility-test.js
@@ -80,5 +80,17 @@ describe('app.client.auditAccessibility()', function () {
           expect(audit.results[0].severity).to.equal('Severe')
         })
     })
+
+    it('ignores rules when ignoreRules is specified', function () {
+      return app.client.waitUntilWindowLoaded()
+        .auditAccessibility({ignoreRules: ['AX_TEXT_01', 'AX_HTML_01']}).then(function (audit) {
+          expect(audit.failed).to.be.true
+          expect(audit.results).to.have.length(1)
+
+          expect(audit.results[0].code).to.equal('AX_COLOR_01')
+          expect(audit.results[0].elements).to.deep.equal(['DIV'])
+          expect(audit.results[0].severity).to.equal('Warning')
+        })
+    })
   })
 })


### PR DESCRIPTION
Adds a new `ignoreRules` option to `auditAccessibility(options)` that is a list of string rule code values available at https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules to ignore violations of.

```js
app.client.auditAccessibility({ignoreRules: ['AX_COLOR_01']})
```

Refs #79 