### PR TITLE
Add Application.getSettings() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,13 @@ application has stopped.
 Stops the application and then starts it. Returns a `Promise` that will be
 resolved once the application has started again.
 
+#### getSettings()
+
+Get all the configured options passed to the `new Application()` constructor.
+This will include the default options values currently being used.
+
+Returns an `Object`.
+
 #### client.getMainProcessLogs()
 
 Gets the `console` log output from the main process. The logs are cleared

--- a/lib/application.js
+++ b/lib/application.js
@@ -93,6 +93,10 @@ Application.prototype.exists = function () {
     // Binary path is ignored by ChromeDriver if debuggerAddress is set
     if (self.debuggerAddress) return resolve()
 
+    if (typeof self.path !== 'string') {
+      return reject(Error('Application path must be a string'))
+    }
+
     fs.stat(self.path, function (error, stat) {
       if (error) return reject(error)
       if (stat.isFile()) return resolve()

--- a/lib/application.js
+++ b/lib/application.js
@@ -87,6 +87,26 @@ Application.prototype.isRunning = function () {
   return this.running
 }
 
+Application.prototype.getSettings = function () {
+  return {
+    host: this.host,
+    port: this.port,
+    quitTimeout: this.quitTimeout,
+    startTimeout: this.startTimeout,
+    waitTimeout: this.waitTimeout,
+    connectionRetryCount: this.connectionRetryCount,
+    connectionRetryTimeout: this.connectionRetryTimeout,
+    nodePath: this.nodePath,
+    path: this.path,
+    args: this.args,
+    env: this.env,
+    workingDirectory: this.workingDirectory,
+    debuggerAddress: this.debuggerAddress,
+    chromeDriverLogPath: this.chromeDriverLogPath,
+    requireName: this.requireName
+  }
+}
+
 Application.prototype.exists = function () {
   var self = this
   return new Promise(function (resolve, reject) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
-    "electron-prebuilt": "~1.2.0",
+    "electron": "~1.3.1",
     "mocha": "^2.3.3",
     "standard": "^5.3.1",
     "temp": "^0.8.3"

--- a/test/application-test.js
+++ b/test/application-test.js
@@ -73,6 +73,10 @@ describe('application loading', function () {
     return app.mainProcess.cwd().should.eventually.equal(path.join(__dirname, 'fixtures'))
   })
 
+  it('throws an error when no path is specified', function () {
+    return new Application().start().should.be.rejectedWith(Error, 'Application path must be a string')
+  })
+
   describe('start()', function () {
     it('rejects with an error if the application does not exist', function () {
       return new Application({path: path.join(__dirname, 'invalid')})

--- a/test/application-test.js
+++ b/test/application-test.js
@@ -129,7 +129,7 @@ describe('application loading', function () {
     it('returns an object with all the configured options', function () {
       expect(app.getSettings().port).to.equal(9515)
       expect(app.getSettings().quitTimeout).to.equal(1000)
-      expect(app.getSettings().env.FOO).to.equal('bar')
+      expect(app.getSettings().env.SPECTRON_TEMP_DIR).to.equal(tempPath)
     })
   })
 

--- a/test/application-test.js
+++ b/test/application-test.js
@@ -125,6 +125,14 @@ describe('application loading', function () {
     })
   })
 
+  describe('getSettings()', function () {
+    it('returns an object with all the configured options', function () {
+      expect(app.getSettings().port).to.equal(9515)
+      expect(app.getSettings().quitTimeout).to.equal(1000)
+      expect(app.getSettings().env.FOO).to.equal('bar')
+    })
+  })
+
   describe('getRenderProcessLogs', function () {
     it('gets the render process console logs and clears them', function () {
       return app.client.waitUntilWindowLoaded()


### PR DESCRIPTION
This adds a new `getSettings` API to `Application` that can be used to get all the configured options with their defaults.

This can be helpful when debugging to ensure options are being set/interpreted correctly.