### PR TITLE
Properly reject promise when waitUntil functions fail

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -213,12 +213,12 @@ Application.prototype.addCommands = function () {
 
   this.client.addCommand('waitUntilWindowLoaded', function (timeout) {
     return this.waitUntil(function () {
-      return this.isWindowLoading().then(function (loading) {
+      return this.webContents.isLoading().then(function (loading) {
         return !loading
       })
     }, timeout).then(function () { }, function (error) {
       error.message = 'waitUntilWindowLoaded ' + error.message
-      return error
+      throw error
     })
   })
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -199,12 +199,15 @@ Application.prototype.initializeClient = function (resolve, reject) {
 Application.prototype.addCommands = function () {
   this.client.addCommand('waitUntilTextExists', function (selector, text, timeout) {
     return this.waitUntil(function () {
-      return this.isExisting(selector).getText(selector).then(function (selectorText) {
-        return selectorText.indexOf(text) !== -1
+      return this.isExisting(selector).then(function (exists) {
+        if (!exists) return false
+        return this.getText(selector).then(function (selectorText) {
+          return selectorText.indexOf(text) !== -1
+        })
       })
     }, timeout).then(function () { }, function (error) {
       error.message = 'waitUntilTextExists ' + error.message
-      return error
+      throw error
     })
   })
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/electron/spectron#readme",
   "dependencies": {
     "dev-null": "^0.1.1",
-    "electron-chromedriver": "~1.3.0",
+    "electron-chromedriver": "~1.3.2",
     "request": "^2.65.0",
     "split": "^1.0.0",
     "webdriverio": "^4.0.4"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Easily test your Electron apps using ChromeDriver and WebdriverIO.",
   "main": "index.js",
   "scripts": {
-    "test": "standard && mocha"
+    "test": "mocha && standard"
   },
   "engines": {
     "node": ">=0.12.4"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
-    "electron": "~1.3.1",
+    "electron": "~1.3.5",
     "mocha": "^2.3.3",
     "standard": "^5.3.1",
     "temp": "^0.8.3"

--- a/test/commands-test.js
+++ b/test/commands-test.js
@@ -29,6 +29,20 @@ describe('window commands', function () {
     })
   })
 
+  describe('waitUntilTextExists', function () {
+    it('resolves if the element contains the given text', function () {
+      return app.client.waitUntilTextExists('html', 'Hello').should.be.fulfilled
+    })
+
+    it('rejects if the element is missing', function () {
+      return app.client.waitUntilTextExists('#not-in-page', 'Hello', 50).should.be.rejectedWith(Error, 'waitUntilTextExists Promise was rejected')
+    })
+
+    it('rejects if the element never contains the text', function () {
+      return app.client.waitUntilTextExists('html', 'not on page', 50).should.be.rejectedWith(Error, 'waitUntilTextExists Promise was rejected')
+    })
+  })
+
   describe('browserWindow.getBounds()', function () {
     it('gets the window bounds', function () {
       return app.browserWindow.getBounds().should.eventually.deep.equal({

--- a/test/fixtures/slow/index.html
+++ b/test/fixtures/slow/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>Test</title>
-    <link rel="stylesheet" href="https://github.com/electron/spectron/styles.css" media="screen" title="no title">
+    <link rel="stylesheet" href="https://github.com/electron/spectron/styles1.css" media="screen" title="no title">
+    <link rel="stylesheet" href="https://github.com/electron/spectron/styles2.css" media="screen" title="no title">
+    <link rel="stylesheet" href="https://github.com/electron/spectron/styles3.css" media="screen" title="no title">
+    <link rel="stylesheet" href="https://github.com/electron/spectron/styles4.css" media="screen" title="no title">
+    <link rel="stylesheet" href="https://github.com/electron/spectron/styles5.css" media="screen" title="no title">
   </head>
 </html>

--- a/test/fixtures/slow/index.html
+++ b/test/fixtures/slow/index.html
@@ -3,6 +3,6 @@
   <head>
     <meta charset="utf-8">
     <title>Test</title>
-    <link rel="stylesheet" href="http://localhost:3000/does/not/exist" media="screen" title="no title">
+    <link rel="stylesheet" href="https://github.com/electron/spectron/styles.css" media="screen" title="no title">
   </head>
 </html>

--- a/test/fixtures/slow/index.html
+++ b/test/fixtures/slow/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>Test</title>
-    <link rel="stylesheet" href="https://github.com/electron/spectron/styles1.css" media="screen" title="no title">
-    <link rel="stylesheet" href="https://github.com/electron/spectron/styles2.css" media="screen" title="no title">
-    <link rel="stylesheet" href="https://github.com/electron/spectron/styles3.css" media="screen" title="no title">
-    <link rel="stylesheet" href="https://github.com/electron/spectron/styles4.css" media="screen" title="no title">
-    <link rel="stylesheet" href="https://github.com/electron/spectron/styles5.css" media="screen" title="no title">
+    <link rel="stylesheet" href="https://github.com/electron/spectron/styles1.css">
+    <link rel="stylesheet" href="https://github.com/electron/spectron/styles2.css">
+    <link rel="stylesheet" href="https://github.com/electron/spectron/styles3.css">
+    <link rel="stylesheet" href="https://github.com/electron/spectron/styles4.css">
+    <link rel="stylesheet" href="https://github.com/electron/spectron/styles5.css">
   </head>
 </html>

--- a/test/fixtures/slow/index.html
+++ b/test/fixtures/slow/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Test</title>
+    <link rel="stylesheet" href="http://localhost:3000/does/not/exist" media="screen" title="no title">
+  </head>
+</html>

--- a/test/fixtures/slow/main.js
+++ b/test/fixtures/slow/main.js
@@ -1,0 +1,20 @@
+var app = require('electron').app
+var BrowserWindow = require('electron').BrowserWindow
+
+var mainWindow = null
+
+app.on('ready', function () {
+  mainWindow = new BrowserWindow({
+    x: 25,
+    y: 35,
+    width: 200,
+    height: 100
+  })
+  mainWindow.loadURL('file://' + __dirname + '/index.html')
+  mainWindow.on('closed', function () { mainWindow = null })
+  mainWindow.webContents.session.enableNetworkEmulation({
+    latency: 60000,
+    downloadThroughput: 100,
+    uploadThroughput: 100
+  })
+})

--- a/test/fixtures/slow/package.json
+++ b/test/fixtures/slow/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "Slow Page",
+  "version": "1.0.0",
+  "main": "main.js"
+}

--- a/test/slow-page-test.js
+++ b/test/slow-page-test.js
@@ -6,7 +6,7 @@ var it = global.it
 var beforeEach = global.beforeEach
 var afterEach = global.afterEach
 
-describe.only('Slow loading page', function () {
+describe('Slow loading page', function () {
   helpers.setupTimeout(this)
 
   var app = null

--- a/test/slow-page-test.js
+++ b/test/slow-page-test.js
@@ -1,0 +1,35 @@
+var helpers = require('./global-setup')
+var path = require('path')
+
+var describe = global.describe
+var it = global.it
+var beforeEach = global.beforeEach
+var afterEach = global.afterEach
+
+describe.only('Slow loading page', function () {
+  helpers.setupTimeout(this)
+
+  var app = null
+
+  beforeEach(function () {
+    return helpers.startApplication({
+      args: [path.join(__dirname, 'fixtures', 'slow')]
+    }).then(function (startedApp) { app = startedApp })
+  })
+
+  afterEach(function () {
+    return helpers.stopApplication(app)
+  })
+
+  describe('webContents.isLoading()', function () {
+    it('resolves to true', function () {
+      return app.webContents.isLoading().should.eventually.be.true
+    })
+  })
+
+  describe('waitUntilWindowLoaded(timeout)', function () {
+    it('rejects with an error when the timeout is hit', function () {
+      return app.client.waitUntilWindowLoaded().should.be.rejectedWith(Error, 'waitUntilWindowLoaded Promise was rejected')
+    })
+  })
+})


### PR DESCRIPTION
Both `waitUntilTextExists` and `waitUntilWindowLoaded` were resolving to `Error` objects instead of rejecting with `Error` objects on failures.

This behavior was also causing a runtime error in `waitUntilWindowLoaded` to never surface and silently fail.

This pull request addresses the issues and adds spec coverage for a page that is slow to load.

Closes #113 