### PR TITLE
Update node settings in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ branches:
   only:
     - master
 
-env:
-  - NODE_VERSION="4.2.1"
-
 script: ./script/travis-build.sh
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ os:
   - linux
   - osx
 
+language: node_js
+
+node_js:
+  - '4'
+
 branches:
   only:
     - master

--- a/script/travis-build.sh
+++ b/script/travis-build.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-git clone https://github.com/creationix/nvm.git /tmp/.nvm
-source /tmp/.nvm/nvm.sh
-nvm install "$NODE_VERSION"
-nvm use --delete-prefix "$NODE_VERSION"
-
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   export DISPLAY=:99.0
   sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
Travis now supports `node_js` Mac workers so remove the previously added extra `nvm` config.