### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ your tests you would do:
 
 ```js
 app.rendererProcess.env().then(function (env) {
-  console.log('main process args: ' + env)
+  console.log('renderer process env variables: ' + env)
 })
 ```
 


### PR DESCRIPTION
Fixed a typo in an example in a README, it appears to be a copy-and-paste mistake.