### PR TITLE
Upgrade to Electron 1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/electron/spectron#readme",
   "dependencies": {
     "dev-null": "^0.1.1",
-    "electron-chromedriver": "~1.3.2",
+    "electron-chromedriver": "~1.4.0",
     "request": "^2.65.0",
     "split": "^1.0.0",
     "webdriverio": "^4.0.4"
@@ -35,7 +35,7 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
-    "electron": "~1.3.5",
+    "electron": "~1.4.0",
     "mocha": "^2.3.3",
     "standard": "^5.3.1",
     "temp": "^0.8.3"


### PR DESCRIPTION
Upgrade Electron and Chromedriver dependency for the 1.4 release last week.