### PR TITLE
Minor Version Clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,23 @@ Easily test your [Electron](http://electron.atom.io) apps using
 [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver) and
 [WebdriverIO](http://webdriver.io).
 
-This minor version of this library tracks the minor version of the Electron
-versions released. So if you are using Electron `1.0.x` you would want to use
-a `spectron` dependency of `~3.0.0` in your `package.json` file.
-
 Learn more from [this presentation](https://speakerdeck.com/kevinsawicki/testing-your-electron-apps-with-chromedriver).
 
 :rotating_light: Upgrading from `1.x` to `2.x`/`3.x`? Read the [changelog](https://github.com/electron/spectron/blob/master/CHANGELOG.md).
 
-## Using
+## Installation
 
 ```sh
 npm install --save-dev spectron
 ```
+
+Note: The minor version of Spectron is compatible with the same minor version
+of Electron. For example, if you are using `electron@1.6.x` you should use
+`spectron@3.6.x` in your `package.json` file, as it has the same minor version
+of `6`. For more details see
+[Electron Versioning](https://electron.atom.io/docs/tutorial/electron-versioning/).
+
+## Usage
 
 Spectron works with any testing framework but the following example uses
 [mocha](https://mochajs.org):

--- a/lib/application.js
+++ b/lib/application.js
@@ -7,6 +7,8 @@ var path = require('path')
 var WebDriver = require('webdriverio')
 
 function Application (options) {
+  require('./check-minor-version')()
+
   options = options || {}
   this.host = options.host || '127.0.0.1'
   this.port = parseInt(options.port, 10) || 9515

--- a/lib/application.js
+++ b/lib/application.js
@@ -5,6 +5,7 @@ var DevNull = require('dev-null')
 var fs = require('fs')
 var path = require('path')
 var WebDriver = require('webdriverio')
+var checkMinorVersion = require('./check-minor-version')
 
 function Application (options) {
   options = options || {}
@@ -31,7 +32,7 @@ function Application (options) {
 
   this.api = new Api(this, this.requireName)
   this.setupPromiseness()
-  require('./check-minor-version')(this)
+  checkMinorVersion(this)
 }
 
 Application.prototype.setupPromiseness = function () {

--- a/lib/application.js
+++ b/lib/application.js
@@ -1,11 +1,11 @@
 var Accessibility = require('./accessibility')
 var Api = require('./api')
+var checkMinorVersion = require('./check-minor-version')
 var ChromeDriver = require('./chrome-driver')
 var DevNull = require('dev-null')
 var fs = require('fs')
 var path = require('path')
 var WebDriver = require('webdriverio')
-var checkMinorVersion = require('./check-minor-version')
 
 function Application (options) {
   options = options || {}

--- a/lib/application.js
+++ b/lib/application.js
@@ -174,8 +174,8 @@ Application.prototype.createClient = function () {
     }
 
     if (self.webdriverLogPath) {
-      options.logOutput = self.webdriverLogPath;
-      options.logLevel = 'verbose';
+      options.logOutput = self.webdriverLogPath
+      options.logLevel = 'verbose'
     }
 
     self.client = WebDriver.remote(options)

--- a/lib/application.js
+++ b/lib/application.js
@@ -32,7 +32,7 @@ function Application (options) {
 
   this.api = new Api(this, this.requireName)
   this.setupPromiseness()
-  checkMinorVersion(this)
+  checkMinorVersion(this.path)
 }
 
 Application.prototype.setupPromiseness = function () {

--- a/lib/application.js
+++ b/lib/application.js
@@ -7,8 +7,6 @@ var path = require('path')
 var WebDriver = require('webdriverio')
 
 function Application (options) {
-  require('./check-minor-version')()
-
   options = options || {}
   this.host = options.host || '127.0.0.1'
   this.port = parseInt(options.port, 10) || 9515
@@ -33,6 +31,7 @@ function Application (options) {
 
   this.api = new Api(this, this.requireName)
   this.setupPromiseness()
+  require('./check-minor-version')(this)
 }
 
 Application.prototype.setupPromiseness = function () {

--- a/lib/check-minor-version.js
+++ b/lib/check-minor-version.js
@@ -1,9 +1,10 @@
 var semver = require('semver')
+var getElectronVersion = require('electron-version')
 
 module.exports = function (app) {
   if (!app || !app.path) return
 
-  require('electron-version')(app.path || 'electron', function (err, electronVersion) {
+  getElectronVersion(app.path || 'electron', function (err, electronVersion) {
     if (err || !electronVersion || !electronVersion.length) return
     electronVersion = electronVersion.replace('v', '')
     var spectronVersion = require('../package.json').version

--- a/lib/check-minor-version.js
+++ b/lib/check-minor-version.js
@@ -1,0 +1,16 @@
+var semver = require('semver')
+
+module.exports = function () {
+  require('electron-version')(function (err, electronVersion) {
+    if (err) throw err
+    electronVersion = electronVersion.replace('v', '')
+    var spectronVersion = require('../package.json').version
+    var spectronMinor = semver.parse(spectronVersion).minor
+    var electronMinor = semver.parse(electronVersion).minor
+    if (spectronMinor !== electronMinor) {
+      console.warn(`\nWarning: Installed minor versions are mismatched: ${spectronMinor} vs ${electronMinor}`)
+      console.warn(`spectron: ${spectronVersion}`)
+      console.warn(`electron: ${electronVersion}\n`)
+    }
+  })
+}

--- a/lib/check-minor-version.js
+++ b/lib/check-minor-version.js
@@ -1,7 +1,7 @@
 var semver = require('semver')
 
-module.exports = function () {
-  require('electron-version')(function (err, electronVersion) {
+module.exports = function (app) {
+  require('electron-version')(app.path || 'electron', function (err, electronVersion) {
     if (err) throw err
     electronVersion = electronVersion.replace('v', '')
     var spectronVersion = require('../package.json').version

--- a/lib/check-minor-version.js
+++ b/lib/check-minor-version.js
@@ -1,8 +1,10 @@
 var semver = require('semver')
 
 module.exports = function (app) {
+  if (!app || !app.path) return
+
   require('electron-version')(app.path || 'electron', function (err, electronVersion) {
-    if (err) throw err
+    if (err || !electronVersion || !electronVersion.length) return
     electronVersion = electronVersion.replace('v', '')
     var spectronVersion = require('../package.json').version
     var spectronMinor = semver.parse(spectronVersion).minor

--- a/lib/check-minor-version.js
+++ b/lib/check-minor-version.js
@@ -1,5 +1,5 @@
-var semver = require('semver')
 var getElectronVersion = require('electron-version')
+var semver = require('semver')
 
 module.exports = function (app) {
   if (!app || !app.path) return

--- a/lib/check-minor-version.js
+++ b/lib/check-minor-version.js
@@ -1,10 +1,10 @@
 var getElectronVersion = require('electron-version')
 var semver = require('semver')
 
-module.exports = function (app) {
-  if (!app || !app.path) return
+module.exports = function (electronPath) {
+  if (!electronPath || !electronPath.length) return
 
-  getElectronVersion(app.path || 'electron', function (err, electronVersion) {
+  getElectronVersion(electronPath, function (err, electronVersion) {
     if (err || !electronVersion || !electronVersion.length) return
     electronVersion = electronVersion.replace('v', '')
     var spectronVersion = require('../package.json').version

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
-    "electron": "^1.6.2",
+    "electron": "~1.6.2",
     "mocha": "^2.3.3",
     "standard": "^5.3.1",
     "temp": "^0.8.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectron",
-  "version": "3.7.0",
+  "version": "3.6.0",
   "description": "Easily test your Electron apps using ChromeDriver and WebdriverIO.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectron",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Easily test your Electron apps using ChromeDriver and WebdriverIO.",
   "main": "index.js",
   "scripts": {
@@ -28,14 +28,16 @@
   "dependencies": {
     "dev-null": "^0.1.1",
     "electron-chromedriver": "~1.6.0",
+    "electron-version": "^1.0.2",
     "request": "^2.65.0",
+    "semver": "^5.3.0",
     "split": "^1.0.0",
     "webdriverio": "^4.0.4"
   },
   "devDependencies": {
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
-    "electron": "~1.6.0",
+    "electron": "^1.6.2",
     "mocha": "^2.3.3",
     "standard": "^5.3.1",
     "temp": "^0.8.3"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "dev-null": "^0.1.1",
     "electron-chromedriver": "~1.6.0",
-    "electron-version": "^1.0.2",
+    "electron-version": "^1.1.0",
     "request": "^2.65.0",
     "semver": "^5.3.0",
     "split": "^1.0.0",


### PR DESCRIPTION
This PR will make Spectron log a warning if Electron is installed and has a minor version that differs from the installed Spectron. The goal is to prevent headaches for users who install and try to use Spectron without closely reading the docs.

@kevinsawicki I'm not sure if this is the right way to approach this. If you think it's worth pursuing I can figure out a way to add some tests for it.

If you're not into the warning idea, let's just ship the commit that updates the README.