### PR TITLE
Allow logging of Webdriver output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Create a new application with the following options:
 * `debuggerAddress` - String address of a Chrome debugger server to connect to.
 * `chromeDriverLogPath` - String path to file to store ChromeDriver logs in.
   Setting this option enables `--verbose` logging when starting ChromeDriver.
+* `webdriverLogPath` - String path to a directory where Webdriver will write
+  logs to. Setting this option enables `verbose` logging from Webdriver.
 
 ### Node Integration
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -26,6 +26,7 @@ function Application (options) {
   this.workingDirectory = options.cwd || process.cwd()
   this.debuggerAddress = options.debuggerAddress
   this.chromeDriverLogPath = options.chromeDriverLogPath
+  this.webdriverLogPath = options.webdriverLogPath
   this.requireName = options.requireName || 'require'
 
   this.api = new Api(this, this.requireName)
@@ -169,6 +170,11 @@ Application.prototype.createClient = function () {
         }
       },
       logOutput: DevNull()
+    }
+
+    if (self.webdriverLogPath) {
+      options.logOutput = self.webdriverLogPath;
+      options.logLevel = 'verbose';
     }
 
     self.client = WebDriver.remote(options)


### PR DESCRIPTION
User may provide a `webdriverLogPath` option when instantiating an
`Application` which switches Webdriver to verbose logging to files in
the specified directory.