### PR TITLE
remove superfluous content from package.json

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -173,8 +173,8 @@ Application.prototype.createClient = function () {
     }
 
     if (self.webdriverLogPath) {
-      options.logOutput = self.webdriverLogPath;
-      options.logLevel = 'verbose';
+      options.logOutput = self.webdriverLogPath
+      options.logLevel = 'verbose'
     }
 
     self.client = WebDriver.remote(options)

--- a/package.json
+++ b/package.json
@@ -9,10 +9,7 @@
   "engines": {
     "node": ">=0.12.4"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/electron/spectron.git"
-  },
+  "repository": "https://github.com/electron/spectron",
   "keywords": [
     "electron",
     "chromedriver",
@@ -21,10 +18,6 @@
   ],
   "author": "Kevin Sawicki",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/electron/spectron/issues"
-  },
-  "homepage": "https://github.com/electron/spectron#readme",
   "dependencies": {
     "dev-null": "^0.1.1",
     "electron-chromedriver": "~1.6.0",


### PR DESCRIPTION
`bugs` and `homepage` are not used by the npm website, and since they don't differ from the `repository` URL, they're just added noise.