### PR TITLE
fix deprecated .timeoutsAsyncScript by using .timeouts

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -46,7 +46,7 @@ Application.prototype.start = function () {
     .then(function () { return self.startChromeDriver() })
     .then(function () { return self.createClient() })
     .then(function () { return self.api.initialize() })
-    .then(function () { return self.client.timeoutsAsyncScript(self.waitTimeout) })
+    .then(function () { return self.client.timeouts('script', self.waitTimeout) })
     .then(function () { self.running = true })
     .then(function () { return self })
 }


### PR DESCRIPTION
`.timeoutsAsyncScript` has been deprecated, see http://webdriver.io/api/protocol/timeoutsAsyncScript.html. This caused it to frequently print this warning during tests:

> WARNING: the "timeoutsAsyncScript" command will be depcrecated soon. Please use a different command in order to avoid failures in your test after updating WebdriverIO.

The documentation for `.timeouts` can be found here: http://webdriver.io/api/protocol/timeouts.html