### PR TITLE
Add missing type definition for waitUntilTextExists()

### DIFF
--- a/lib/spectron.d.ts
+++ b/lib/spectron.d.ts
@@ -19,7 +19,7 @@ declare module "spectron" {
          * Wait until the element matching the given selector contains the given text.
          * Takes an optional timeout in milliseconds that defaults to 5000.
          */
-        waitUntilTextExists(selector: string, text: string, timeout?: number)
+        waitUntilTextExists(selector:string, text:string, timeout?:number):Promise<void>;
         
         /**
          * Gets the number of open windows. <webview> tags are also counted as separate windows.

--- a/lib/spectron.d.ts
+++ b/lib/spectron.d.ts
@@ -14,6 +14,13 @@ declare module "spectron" {
          * Takes an optional timeout in milliseconds that defaults to 5000.
          */
         waitUntilWindowLoaded(timeout?:number):Promise<void>;
+        
+        /**
+         * Wait until the element matching the given selector contains the given text.
+         * Takes an optional timeout in milliseconds that defaults to 5000.
+         */
+        waitUntilTextExists(selector: string, text: string, timeout?: number)
+        
         /**
          * Gets the number of open windows. <webview> tags are also counted as separate windows.
          */


### PR DESCRIPTION
Adds waitUntilTextExists(), as documented in the README, to the type definition file.