### PR TITLE
Make all tests pass on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ install:
 test_script:
   - node --version
   - .\node_modules\.bin\npm --version
-  - .\node_modules\.bin\mocha -g "opens a window"
+  - .\node_modules\.bin\mocha

--- a/package.json
+++ b/package.json
@@ -21,16 +21,17 @@
   "license": "MIT",
   "dependencies": {
     "dev-null": "^0.1.1",
-    "electron-chromedriver": "~1.7.0",
-    "request": "^2.65.0",
+    "electron-chromedriver": "~1.7.1",
+    "request": "^2.81.0",
     "split": "^1.0.0",
-    "webdriverio": "^4.0.4"
+    "webdriverio": "^4.8.0"
   },
   "devDependencies": {
-    "chai": "^3.3.0",
-    "chai-as-promised": "^5.1.0",
+    "chai": "^3.5.0",
+    "chai-as-promised": "^6.0.0",
+    "chai-roughly": "^1.0.0",
     "electron": "~1.7.0",
-    "mocha": "^2.3.3",
+    "mocha": "^3.4.1",
     "standard": "^5.3.1",
     "temp": "^0.8.3"
   }

--- a/test/application-test.js
+++ b/test/application-test.js
@@ -42,7 +42,7 @@ describe('application loading', function () {
   it('launches the application', function () {
     return app.client.windowHandles().then(function (response) {
       assert.equal(response.value.length, 1)
-    }).browserWindow.getBounds().should.eventually.deep.equal({
+    }).browserWindow.getBounds().should.eventually.roughly(5).deep.equal({
       x: 25,
       y: 35,
       width: 200,

--- a/test/commands-test.js
+++ b/test/commands-test.js
@@ -73,7 +73,9 @@ describe('window commands', function () {
 
   describe('browserWindow.isFocused()', function () {
     it('returns true when the current window is focused', function () {
-      return app.browserWindow.isFocused().should.eventually.be.true
+      return app
+        .browserWindow.show()
+        .browserWindow.isFocused().should.eventually.be.true
     })
   })
 

--- a/test/commands-test.js
+++ b/test/commands-test.js
@@ -45,7 +45,7 @@ describe('window commands', function () {
 
   describe('browserWindow.getBounds()', function () {
     it('gets the window bounds', function () {
-      return app.browserWindow.getBounds().should.eventually.deep.equal({
+      return app.browserWindow.getBounds().should.eventually.roughly(5).deep.equal({
         x: 25,
         y: 35,
         width: 200,
@@ -59,14 +59,14 @@ describe('window commands', function () {
       return app.browserWindow.setBounds({
         x: 100,
         y: 200,
-        width: 50,
-        height: 75
+        width: 150, // Windows minimum is ~100px
+        height: 130
       })
-      .browserWindow.getBounds().should.eventually.deep.equal({
+      .browserWindow.getBounds().should.eventually.roughly(5).deep.equal({
         x: 100,
         y: 200,
-        width: 50,
-        height: 75
+        width: 150,
+        height: 130
       })
     })
   })

--- a/test/global-setup.js
+++ b/test/global-setup.js
@@ -2,11 +2,14 @@ var Application = require('..').Application
 var assert = require('assert')
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
+var chaiRoughly = require('chai-roughly')
+
 var path = require('path')
 
 global.before(function () {
   chai.should()
   chai.use(chaiAsPromised)
+  chai.use(chaiRoughly)
 })
 
 exports.getElectronPath = function () {

--- a/test/multi-window-test.js
+++ b/test/multi-window-test.js
@@ -25,7 +25,7 @@ describe('multiple windows', function () {
     return app.client
       .getWindowCount().should.eventually.equal(2)
       .windowByIndex(1)
-        .browserWindow.getBounds().should.eventually.deep.equal({
+        .browserWindow.getBounds().should.eventually.roughly(5).deep.equal({
           x: 25,
           y: 35,
           width: 200,
@@ -33,7 +33,7 @@ describe('multiple windows', function () {
         })
         .getTitle().should.eventually.equal('Top')
       .windowByIndex(0)
-        .browserWindow.getBounds().should.eventually.deep.equal({
+        .browserWindow.getBounds().should.eventually.roughly(5).deep.equal({
           x: 25,
           y: 135,
           width: 300,

--- a/test/require-name-test.js
+++ b/test/require-name-test.js
@@ -24,7 +24,7 @@ describe('requireName option to Application', function () {
 
   it('uses the custom require name to load the electron module', function () {
     return app.client.waitUntilWindowLoaded()
-      .browserWindow.getBounds().should.eventually.deep.equal({
+      .browserWindow.getBounds().should.eventually.roughly(5).deep.equal({
         x: 25,
         y: 35,
         width: 200,

--- a/test/web-view-test.js
+++ b/test/web-view-test.js
@@ -22,7 +22,10 @@ describe('<webview> tags', function () {
   })
 
   it('allows the web view to be accessed', function () {
-    return app.client.waitUntilWindowLoaded()
+    // waiting for windowHandles ensures waitUntilWindowLoaded doesn't access a nil webContents.
+    // TODO: this issue should be fixed by waitUntilWindowLoaded instead of this workaround.
+    return app.client.windowHandles()
+      .waitUntilWindowLoaded()
       .waitUntil(function () {
         return this.getWindowCount().then(function (count) {
           return count === 2


### PR DESCRIPTION
Previously, appveyor ran a single "does it not explode" test. They were presumably disabled due to Windows' window dimension functions being mostly-correct (where widths and heights report 2-5 pixels more than the requested dimensions, presumably due to borders). By adding the chai-roughly package, we can "deep-eql" the dimensions with a small (5) allowable delta.

All tests now pass on Windows 10 build 15063 lodpi and hidpi displays.

I updated the request module in `package.json` to fix the vulnerability shown here: https://david-dm.org/electron/spectron