### PR TITLE
Update typings for WebDriver logging support

### DIFF
--- a/lib/spectron.d.ts
+++ b/lib/spectron.d.ts
@@ -130,6 +130,11 @@ declare module "spectron" {
          */
         chromeDriverLogPath?:string,
         /**
+         * String path to a directory where Webdriver will write logs to.
+         * Setting this option enables verbose logging from Webdriver.
+         */
+        webdriverLogPath?:string,
+        /**
          * Custom property name to use when requiring modules.
          * Defaults to require.
          * This should only be used if your application deletes the main window.require function


### PR DESCRIPTION
I took the info from the README.

It fixes this Typescript compile error:
```
error TS2345: Argument of type '{ path: string; args: string[]; webdriverLogPath...' is not assignable to parameter of type 'AppConstructorOptions'.
Object literal may only specify known properties, and 'webdriverLogPath' does not exist in type 'AppConstructorOptions'.
```