### PR TITLE
Fix missing webdriver log path in typing (Spectron 3.6.x)

### DIFF
--- a/lib/spectron.d.ts
+++ b/lib/spectron.d.ts
@@ -123,6 +123,11 @@ declare module "spectron" {
          */
         chromeDriverLogPath?:string,
         /**
+         * String path to a directory where Webdriver will write logs to.
+         * Setting this option enables verbose logging from Webdriver.
+         */
+        webdriverLogPath?:string,
+        /**
          * Custom property name to use when requiring modules.
          * Defaults to require.
          * This should only be used if your application deletes the main window.require function


### PR DESCRIPTION
That's the same change as in PR #204 but for Spectron 3.6.x.