### PR TITLE
Enhance waitUntilTextExists() to find substrings in case the selector matches multiple elements

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -214,7 +214,7 @@ Application.prototype.addCommands = function () {
       return this.isExisting(selector).then(function (exists) {
         if (!exists) return false
         return this.getText(selector).then(function (selectorText) {
-          return selectorText.indexOf(text) !== -1
+          return Array.isArray(selectorText) ? selectorText.some(s => s.includes(text)) : selectorText.includes(text)
         })
       })
     }, timeout).then(function () { }, function (error) {

--- a/test/commands-test.js
+++ b/test/commands-test.js
@@ -30,8 +30,20 @@ describe('window commands', function () {
   })
 
   describe('waitUntilTextExists', function () {
-    it('resolves if the element contains the given text', function () {
-      return app.client.waitUntilTextExists('html', 'Hello').should.be.fulfilled
+    it('resolves if the element (single occurrence) contains the given text - full text', function () {
+      return app.client.waitUntilTextExists('.occurrences-1', 'word1 word2').should.be.fulfilled
+    })
+
+    it('resolves if the element (single occurrence) contains the given text - partial text', function () {
+      return app.client.waitUntilTextExists('.occurrences-1', 'word1').should.be.fulfilled
+    })
+
+    it('resolves if the element (multiple occurrences) contains the given text - full text', function () {
+      return app.client.waitUntilTextExists('.occurrences-2', 'word3 word4').should.be.fulfilled
+    })
+
+    it('resolves if the element (multiple occurrences) contains the given text - partial text', function () {
+      return app.client.waitUntilTextExists('.occurrences-2', 'word3').should.be.fulfilled
     })
 
     it('rejects if the element is missing', function () {

--- a/test/fixtures/app/index.html
+++ b/test/fixtures/app/index.html
@@ -11,6 +11,9 @@
   </head>
   <body>
     Hello
+    <div class="occurrences-1">word1 word2</div>
+    <div class="occurrences-2">word3 word4</div>
+    <div class="occurrences-2">word5 word6</div>
     <textarea rows="10" cols="80"></textarea>
     <div class="keypress-count"></div>
   </body>


### PR DESCRIPTION
Until now substring matching was only working if the selector matched a single element.
If the selector matches multiple elements getText() returns an array instead of a string.
Using indexOf() on an array compares only the full array entry not a substring.
Therefore this case has to be handled especially.