### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ if (process.env.NODE_ENV === 'test') {
 Then create the Spectron `Application` with the `requireName` option set to
 `'electronRequire'` and then runs your tests via `NODE_ENV=test npm test`.
 
-**Note:** This is only required if you tests are accessing any Electron APIs.
+**Note:** This is only required if your tests are accessing any Electron APIs.
 You don't need to do this if you are only accessing the helpers on the `client`
 property which do not require Node integration.
 


### PR DESCRIPTION
This fixes a typo in the **Note** of the **Node Integration** section. 
_This is only required if **you** tests_ -> _This is only required if **your** tests_