### PR TITLE
Use static webdriver version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "electron-chromedriver": "~1.7.1",
     "request": "^2.81.0",
     "split": "^1.0.0",
-    "webdriverio": "^4.8.0"
+    "webdriverio": "4.8.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
This is meant as a temporary fix as to not use the lastest breaking
webdriverio version

as detailed in https://github.com/electron/spectron/issues/244