### PR TITLE
Deprecation warning conf for webdriverio

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Create a new application with the following options:
   Setting this option enables `--verbose` logging when starting ChromeDriver.
 * `webdriverLogPath` - String path to a directory where Webdriver will write
   logs to. Setting this option enables `verbose` logging from Webdriver.
+* `deprecationWarnings` - WebdriverIO configuration parameter. Warns when a
+  deprecated command is used. Defaults to true (in WebdriverIO).
 
 ### Node Integration
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -29,6 +29,7 @@ function Application (options) {
   this.chromeDriverLogPath = options.chromeDriverLogPath
   this.webdriverLogPath = options.webdriverLogPath
   this.requireName = options.requireName || 'require'
+  this.deprecationWarnings = options.deprecationWarnings
 
   this.api = new Api(this, this.requireName)
   this.setupPromiseness()
@@ -181,6 +182,10 @@ Application.prototype.createClient = function () {
     if (self.webdriverLogPath) {
       options.logOutput = self.webdriverLogPath
       options.logLevel = 'verbose'
+    }
+
+    if (self.deprecationWarnings !== undefined) {
+      options.deprecationWarnings = self.deprecationWarnings
     }
 
     self.client = WebDriver.remote(options)

--- a/lib/spectron.d.ts
+++ b/lib/spectron.d.ts
@@ -141,6 +141,11 @@ declare module "spectron" {
          * and assigns it to another property name on window.
          */
         requireName?:string
+        /**
+         * WebdriverIO configuration parameter. Warns when a deprecated command is used.
+         * Defaults to true (in WebdriverIO).
+         */
+        deprecationWarnings?:boolean
     };
     type AppConstructorOptions = BasicAppSettings & {
         /**


### PR DESCRIPTION
WebdriverIO - latest - has a lot of deprecated commands, which are still missing their alternatives.
deprecationWarnings configuration option added to Application object which goes through Wdio, so now We are able to call WebdriverIO with a 'silent' mode, where these deprecations won't affect logs...