### PR TITLE
@types/webdriverio missing in your package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "temp": "^0.8.3",
     "tslint": "^5.4.3",
     "typescript": "^2.3.4",
-    "@types/webdriverio": "4.8.8"
+    "@types/webdriverio": "^4.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
     "node": ">=0.12.4"
   },
   "repository": "https://github.com/electron/spectron",
-  "keywords": [
-    "electron",
-    "chromedriver",
-    "webdriverio",
-    "selenium"
-  ],
+  "keywords": ["electron", "chromedriver", "webdriverio", "selenium"],
   "author": "Kevin Sawicki",
   "license": "MIT",
   "dependencies": {
@@ -40,6 +35,7 @@
     "standard": "^5.3.1",
     "temp": "^0.8.3",
     "tslint": "^5.4.3",
-    "typescript": "^2.3.4"
+    "typescript": "^2.3.4",
+    "@types/webdriverio": "4.8.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "node": ">=0.12.4"
   },
   "repository": "https://github.com/electron/spectron",
-  "keywords": ["electron", "chromedriver", "webdriverio", "selenium"],
+  "keywords": [
+    "electron",
+    "chromedriver",
+    "webdriverio",
+    "selenium"
+  ],
   "author": "Kevin Sawicki",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
![](https://i.imgur.com/98YcE9u.png)
Since your own typings are also depending on the webdriverio, we were getting an error using Spectron without manually installing the typings for webdriverio.

