### PR TITLE
Added 'inAppPurchase' to ignoreModule.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -86,6 +86,7 @@ Api.prototype.loadApi = function () {
         case 'deprecate':
         case 'deprecations':
         case 'hideInternalModules':
+        case 'inAppPurchase':
         case 'Tray':
           return true
       }


### PR DESCRIPTION
Just in case this *is* the actual fix, here's a PR.

If it's true that electron 2.0.0 breaks `spectron` on linux/windows, this will at least be a temporary fix.

At least two issues related to this:
* https://github.com/electron/electron/issues/12471
* https://github.com/gingko/client/issues/57
