### PR TITLE
Fix capturePage for Electron 2.0

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -315,7 +315,7 @@ Api.prototype.addCapturePageSupport = function () {
       if (rect != null) args.push(rect)
       args.push(function (image) {
         if (image != null) {
-          done(image.toPng().toString('base64'))
+          done(image.toPNG().toString('base64'))
         } else {
           done(image)
         }


### PR DESCRIPTION
In Electron `1.2.5`, the `toPng` was changed to `toPNG` and deprecated.  (https://github.com/electron/electron/commit/e9222583cbd354559ec0ab0bb1170567c2ec9d73)
In Electron `2.0.0`, the `toPng` was removed, and only `toPNG` exists now.

This PR ensures `capturePage` is compatible with Electron 2.0, but still works with Electron >= 1.2.5.
