### PR TITLE
Add app option for passing arbitrary chromeOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ Create a new application with the following options:
 * `webdriverLogPath` - String path to a directory where Webdriver will write
   logs to. Setting this option enables `verbose` logging from Webdriver.
 * `webdriverOptions` - Object of additional options for Webdriver
+* `additionalChromeOptions` - Object of additional Chromium options for
+Webdriver. E.g., when testing an electron@2.x application you will want to pass
+``{ windowTypes: ['app', 'webview'] }`` in order to be able to access webviews.
 
 ### Node Integration
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -22,6 +22,7 @@ function Application (options) {
   this.path = options.path
 
   this.args = options.args || []
+  this.additionalChromeOptions = options.additionalChromeOptions || {}
   this.chromeDriverArgs = options.chromeDriverArgs || []
   this.env = options.env || {}
   this.workingDirectory = options.cwd || process.cwd()
@@ -102,6 +103,7 @@ Application.prototype.getSettings = function () {
     nodePath: this.nodePath,
     path: this.path,
     args: this.args,
+    additionalChromeOptions: this.additionalChromeOptions,
     chromeDriverArgs: this.chromeDriverArgs,
     env: this.env,
     workingDirectory: this.workingDirectory,
@@ -168,11 +170,11 @@ Application.prototype.createClient = function () {
       connectionRetryTimeout: self.connectionRetryTimeout,
       desiredCapabilities: {
         browserName: 'electron',
-        chromeOptions: {
+        chromeOptions: Object.assign({
           binary: launcherPath,
           args: args,
           debuggerAddress: self.debuggerAddress
-        }
+        }, self.additionalChromeOptions)
       },
       logOutput: DevNull()
     }


### PR DESCRIPTION
This effectively fixes issue #289.

Aside from adding to the chromeOptions, this will also allow overwriting the options „binary“ (computed internally), and „args“ plus „debuggerAddress“ (options passed into the application constructor), if only inadvertently.