### PR TITLE
Edit WebdriverIO link from latest to v4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,10 @@ Spectron uses [WebdriverIO](http://webdriver.io) and exposes the managed
 `client` property on the created `Application` instances.
 
 The `client` API is WebdriverIO's `browser` object. Documentation can be found
-[here](http://webdriver.io/api.html).
+[here](http://v4.webdriver.io/api.html).
+
+> You should look at the [v4.x WebdriverIO document](http://v4.webdriver.io/api.html). <br>
+The latest version of WebdriverIO is not v4, but Spectron is currently using v4.x. 
 
 Several additional commands are provided specific to Electron.
 


### PR DESCRIPTION
Latest [WebdriverIO](https://webdriver.io/) is v5.3.5. But Spectron use v 4.13.0.

Because of [breaking change of WebdriverIO](https://github.com/webdriverio/webdriverio/blob/master/CHANGELOG.md#v500-2018-12-20), Current latest link doesn't help us. 

So document link must fix it.

[here is v4 documentation of WebdriverIO](http://v4.webdriver.io/api.html)